### PR TITLE
Shakemap content with strings fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2019-11-04:
+
+- Added support for strings in shakemap grid data
+- Added support for intensity aliases to get their value
+  from columns with different names (say one uses MHW, another
+  INUN\_MEAN\_POLY, but both should be used as ID - for inundation)
+
 # 2019-10-28:
 
 - Updated the damage state schema mapping files

--- a/deus.py
+++ b/deus.py
@@ -91,9 +91,9 @@ def main():
     intensity_provider = intensityprovider.AliasIntensityProvider(
         intensity_provider,
         aliases={
-            'SA_01': 'PGA',
-            'SA_03': 'PGA',
-            'ID': 'MWH',
+            'SA_01': ['PGA'],
+            'SA_03': ['PGA'],
+            'ID': ['MWH', 'INUN_MEAN_POLY'],
         }
     )
     fragility_provider = fragility.Fragility.from_file(

--- a/intensityprovider.py
+++ b/intensityprovider.py
@@ -163,13 +163,18 @@ class AliasIntensityProvider():
         )
 
         for new_intensity_measure in self._aliases:
-            given_intensity_measure = self._aliases[new_intensity_measure]
-            if given_intensity_measure in intensities.keys():
-                if new_intensity_measure not in intensities.keys():
-                    intensities[new_intensity_measure] = \
-                        intensities[given_intensity_measure]
-                    units[new_intensity_measure] = \
-                        units[given_intensity_measure]
+            possible_intensity_measures = self._aliases[new_intensity_measure]
+            # the current behaviour is that later names can overwrite
+            # the source columns used before
+            # however it is more indented as an overall use
+            # case for "Use one of this columns if you have none in the data"
+            for given_intensity_measure in possible_intensity_measures:
+                if given_intensity_measure in intensities.keys():
+                    if new_intensity_measure not in intensities.keys():
+                        intensities[new_intensity_measure] = \
+                            intensities[given_intensity_measure]
+                        units[new_intensity_measure] = \
+                            units[given_intensity_measure]
 
         return intensities, units
 

--- a/test_intensity.py
+++ b/test_intensity.py
@@ -55,9 +55,9 @@ class TestIntensity(unittest.TestCase):
         intensity_provider = intensityprovider.AliasIntensityProvider(
             inner_intensity_provider,
             aliases={
-                'SA_01': 'PGA',
-                'SA_03': 'PGA',
-                'ID': 'mwh',
+                'SA_01': ['PGA'],
+                'SA_03': ['PGA'],
+                'ID': ['mwh'],
             }
         )
 

--- a/test_shakemap.py
+++ b/test_shakemap.py
@@ -5,6 +5,87 @@ import unittest
 import shakemap
 
 
+class TestReadShakemapGridData(unittest.TestCase):
+    """
+    This is the test class for reading
+    the content from the grid_data text.
+    """
+
+    def test_one_row_ints(self):
+        """
+        Test with one row of integers.
+        """
+        raw_data = '15 16 17'
+
+        result = list(shakemap.read_shakemap_data_from_str(raw_data))
+
+        self.assertEqual([15, 16, 17], result)
+
+    def test_two_rows_ints(self):
+        """
+        Test with two rows of integers.
+        Here we use a real newline.
+        """
+        raw_data = '15 16 17\n18 19 20'
+
+        result = list(shakemap.read_shakemap_data_from_str(raw_data))
+
+        self.assertEqual([15, 16, 17, 18, 19, 20], result)
+
+    def test_two_rows_without_newline_ints(self):
+        """
+        Simulates the usage of two rows (2x3 values)
+        but the newline was replaced by a simple space.
+        """
+        raw_data = '15 16 17 18 19 20'
+
+        result = list(shakemap.read_shakemap_data_from_str(raw_data))
+
+        self.assertEqual([15, 16, 17, 18, 19, 20], result)
+
+    def test_negative(self):
+        """
+        Test with some negative numbers.
+        """
+        raw_data = '15 -16 17 18 19 -20'
+
+        result = list(shakemap.read_shakemap_data_from_str(raw_data))
+
+        self.assertEqual([15, -16, 17, 18, 19, -20], result)
+
+    def test_quoted(self):
+        """
+        Test with quoted values (double quotes).
+        """
+        raw_data = '"0 1" 1 -71.4786 -33.0123 4 0 0.0 0.0 ' + \
+            '"0 2" 2 -71.5396 -33.0543 48 0 0.0 0.0'
+        result = list(shakemap.read_shakemap_data_from_str(raw_data))
+
+        self.assertEqual(
+            [
+                '0 1', 1, -71.4786, -33.0123, 4, 0, 0.0, 0.0,
+                '0 2', 2, -71.5396, -33.0543, 48, 0, 0.0, 0.0
+            ],
+            result
+        )
+
+    def test_quoted_single(self):
+        """
+        Test with quoted values (single quotes).
+        """
+        raw_data = "'0 1' 1 -71.4786 -33.0123 4 0 0.0 0.0 " + \
+            "'0 2' 2 -71.5396 -33.0543 48 0 0.0 0.0"
+        result = list(shakemap.read_shakemap_data_from_str(raw_data))
+
+        self.assertEqual(
+            [
+                '0 1', 1, -71.4786, -33.0123, 4, 0, 0.0, 0.0,
+                '0 2', 2, -71.5396, -33.0543, 48, 0, 0.0, 0.0
+            ],
+            result
+        )
+
+
 class TestShakemap(unittest.TestCase):
 
     def test_read_ts_shakemap(self):


### PR DESCRIPTION
I added two things:
- possibility to deal with strings in the shakemap grid data (say for ids for the polygons)
- extended alias handling (for having the mwh or inun_mean_poly column to use with fragility models that expect ID (for inundation))