### PR TITLE
Removed name and region from processing

### DIFF
--- a/exposure.py
+++ b/exposure.py
@@ -111,10 +111,9 @@ class ExposureCell:
     '''
     Spatial cell with the exposure data.
     '''
-    def __init__(self, schema, gid, name, geometry, taxonomies):
+    def __init__(self, schema, gid, geometry, taxonomies):
         self.schema = schema
         self.gid = gid
-        self.name = name
         self.geometry = geometry
         self.taxonomies = taxonomies
         self._len_tax = len(taxonomies)
@@ -136,7 +135,7 @@ class ExposureCell:
 
     def without_taxonomies(self, schema=None):
         '''
-        New cell with the same name and geometry
+        New cell with the same geometry
         but without the taxonomy data.
         '''
         if schema is None:
@@ -144,7 +143,6 @@ class ExposureCell:
         return ExposureCell(
             schema=schema,
             gid=self.gid,
-            name=self.name,
             geometry=self.geometry,
             taxonomies=[]
         )
@@ -284,7 +282,6 @@ class ExposureCell:
         Read the exposure cell from a simple series.
         '''
         gid = series['gc_id']
-        name = series['name']
         geometry = series['geometry']
 
         taxonomies = []
@@ -302,7 +299,6 @@ class ExposureCell:
         return cls(
             schema=schema,
             gid=gid,
-            name=name,
             geometry=geometry,
             taxonomies=taxonomies
         )
@@ -314,7 +310,6 @@ class ExposureCell:
         '''
         series = pd.Series({
             'gc_id': self.gid,
-            'name': self.name,
             'geometry': self.geometry,
         })
 
@@ -335,7 +330,6 @@ class ExposureCell:
         '''
         series = pd.Series({
             'gid': self.gid,
-            'name': self.name,
             'geometry': self.geometry,
             'expo': {
                 'Taxonomy': [x["taxonomy"] for x in self.taxonomies],
@@ -345,14 +339,12 @@ class ExposureCell:
                 ],
                 'Buildings': [x["n_buildings"] for x in self.taxonomies],
                 'id': [x["area_id"] for x in self.taxonomies],
-                'Region': [x["region"] for x in self.taxonomies],
                 'Dwellings': [x["dwellings"] for x in self.taxonomies],
                 'Repl-cost-USD-bdg': [
                     x["repl_cost_usd_bdg"]
                     for x in self.taxonomies
                 ],
                 'Population': [x["population"] for x in self.taxonomies],
-                'name': [x["name"] for x in self.taxonomies],
             }
         })
         return series
@@ -365,7 +357,6 @@ class ExposureCell:
         store taxonomies, damage states and the number of buildings.
         '''
         gid = series['gid']
-        name = series['name']
         geometry = series['geometry']
         expo = pd.DataFrame(series['expo'])
 
@@ -381,7 +372,6 @@ class ExposureCell:
         return cls(
             schema=schema,
             gid=gid,
-            name=name,
             geometry=geometry,
             taxonomies=taxonomies
         )
@@ -408,11 +398,9 @@ def tb_from_series(series, schema):
         "damage_state": remove_prefix_d_for_damage_state(series['Damage']),
         "n_buildings": n_buildings,
         "area_id": series['id'],
-        "region": series['Region'],
         "dwellings": series['Dwellings'],
         "repl_cost_usd_bdg": series['Repl-cost-USD-bdg'],
         "population": series['Population'],
-        "name": series['name']
     }
 
 
@@ -430,7 +418,6 @@ def tb_from_simple_series(series, key, schema):
         "taxonomy": extract_taxonomy_from_taxonomy_damage_state_string(key),
         "damage_state": damage_state,
         "n_buildings": n_buildings,
-        "name": series['name']
     }
 
 

--- a/loss.py
+++ b/loss.py
@@ -52,9 +52,8 @@ class LossCell:
     Spatial cell with loss data.
     '''
 
-    def __init__(self, gid, name, geometry, loss_value, loss_unit):
+    def __init__(self, gid, geometry, loss_value, loss_unit):
         self.gid = gid
-        self.name = name
         self.geometry = geometry
         self.loss_value = loss_value
         self.loss_unit = loss_unit
@@ -65,7 +64,6 @@ class LossCell:
         '''
         series = pd.Series({
             'gid': self.gid,
-            'name': self.name,
             'geometry': self.geometry,
             'loss_value': self.loss_value,
             'loss_unit': self.loss_unit,
@@ -93,7 +91,6 @@ class LossCell:
 
         return cls(
             gid=transition_cell.gid,
-            name=transition_cell.name,
             geometry=transition_cell.geometry,
             loss_value=loss_value,
             loss_unit=loss_provider.get_unit()

--- a/test_basics.py
+++ b/test_basics.py
@@ -171,10 +171,6 @@ class TestBasics(unittest.TestCase):
         self.assertEqual(lon, lon2)
         self.assertEqual(lat, lat2)
 
-        self.assertEqual(
-            empty_exposure_cell.name,
-            'example point1')
-
         taxonomies = exposure_cell.taxonomies
 
         search_taxonomy = [
@@ -272,9 +268,6 @@ class TestBasics(unittest.TestCase):
         self.assertEqual(
             updated_series['geometry'],
             transition_series['geometry'])
-        self.assertEqual(
-            updated_series['name'],
-            transition_series['name'])
 
         def filter_transitions(from_damage_state, to_damage_state, taxonomy):
             tst = transition_series['transitions']
@@ -532,7 +525,6 @@ def get_example_exposure_cell():
     '''
     data = pd.DataFrame({
         'geometry': ['POINT(12.0 15.0)'],
-        'name': ['example point1'],
         'gc_id': ['abcdefg'],
         r'MCF\/DNO\/_1': [6],
         r'MUR+STDRE\/': [13],
@@ -554,7 +546,6 @@ def get_exposure_cell_for_sara():
 
     exposure_cell_data = gpd.GeoDataFrame(pd.DataFrame({
         'geometry': ['POINT(12.0 15.0)'],
-        'name': ['example point1'],
         'gc_id': ['abcdefg'],
         'MUR_H1': [100.0],
         'ER_ETR_H1_2_D2': [200.0]

--- a/test_exposure.py
+++ b/test_exposure.py
@@ -26,7 +26,6 @@ class TestExposure(unittest.TestCase):
         geometry2 = wkt.loads('POINT(15 52)')
 
         dataframe = pd.DataFrame({
-            'name': ['Colina', 'Quilpue'],
             'gc_id': ['CHL.14.1.1_1', 'CHL.14.2.1-1'],
             'geometry': [geometry1, geometry2],
             'W+WS/H:1,2': [100.0, 80.0],
@@ -44,9 +43,6 @@ class TestExposure(unittest.TestCase):
 
         self.assertTrue(all(
             dataframe['geometry'] == recreated_dataframe['geometry']
-        ))
-        self.assertTrue(all(
-            dataframe['name'] == recreated_dataframe['name']
         ))
         self.assertTrue(all(
             dataframe['gc_id'] == recreated_dataframe['gc_id']
@@ -68,30 +64,25 @@ class TestExposure(unittest.TestCase):
         geometry2 = wkt.loads('POINT(15 52)')
 
         dataframe = pd.DataFrame({
-            'name': ['Colina', 'Quilpue'],
             'gid': ['CHL.14.1.1_1', 'CHL.14.2.1-1'],
             'geometry': [geometry1, geometry2],
             'expo': [
                 {
                     'id': ['AREA # 13301', 'AREA # 13301'],
-                    'Region': ['Colina', 'Colina'],
                     'Taxonomy': ['W+WS/H:1,2', 'W+WS/H:1,2'],
                     'Dwellings': [107.5, 107.5],
                     'Buildings': [100.0, 50.0],
                     'Repl-cost-USD-bdg': [360000, 450000],
                     'Population': [446.5, 446.5],
-                    'name': ['Colina', 'Colina'],
                     'Damage': ['D0', 'D1']
                 },
                 {
                     'id': ['AREA # 13302', 'AREA # 13302'],
-                    'Region': ['Quilpue', 'Quilpue'],
                     'Taxonomy': ['W+WS/H:1,2', 'W+WS/H:1,2'],
                     'Dwellings': [107.5, 107.5],
                     'Buildings': [80.0, 55.0],
                     'Repl-cost-USD-bdg': [360000, 450000],
                     'Population': [446.5, 446.5],
-                    'name': ['Quilpue', 'Quilpue'],
                     'Damage': ['D0', 'D1']
                 }
             ]
@@ -110,9 +101,6 @@ class TestExposure(unittest.TestCase):
             dataframe['geometry'] == recreated_dataframe['geometry']
         ))
         self.assertTrue(all(
-            dataframe['name'] == recreated_dataframe['name']
-        ))
-        self.assertTrue(all(
             dataframe['gid'] == recreated_dataframe['gid']
         ))
         self.assertTrue(all(
@@ -125,7 +113,6 @@ class TestExposure(unittest.TestCase):
         '''
         geometry1 = wkt.loads('POINT(14 51)')
         series1 = pd.Series({
-            'name': 'Colina',
             'gc_id': 'CHL.14.1.1_1',
             'geometry': geometry1,
             'W+WS/H:1,2': 100.0,
@@ -139,7 +126,6 @@ class TestExposure(unittest.TestCase):
 
         geometry2 = wkt.loads('POINT(15 52)')
         series2 = pd.Series({
-            'name': 'Quilpue',
             'gc_id': 'CHL.14.1.1_1',
             'geometry': geometry2,
             'W+WS/H:1,2': 80.0,
@@ -165,7 +151,6 @@ class TestExposure(unittest.TestCase):
         '''
         geometry = wkt.loads('POINT(14 51)')
         series = pd.Series({
-            'name': 'Colina',
             'gc_id': 'CHL.14.1.1_1',
             'geometry': geometry,
             'W+WS/H:1,2': 100.0,
@@ -179,7 +164,6 @@ class TestExposure(unittest.TestCase):
 
         self.assertEqual('SARA_v1.0', exposure_cell.schema)
         self.assertEqual('CHL.14.1.1_1', exposure_cell.gid)
-        self.assertEqual('Colina', exposure_cell.name)
         self.assertEqual(geometry, exposure_cell.geometry)
         lon, lat = exposure_cell.get_lon_lat_of_centroid()
         self.assertEqual(14, lon)
@@ -197,18 +181,15 @@ class TestExposure(unittest.TestCase):
         '''
         geometry = wkt.loads('POINT(14 51)')
         series = pd.Series({
-            'name': 'Colina',
             'gid': 'CHL.14.1.1_1',
             'geometry': geometry,
             'expo': {
                 'id': ['AREA # 13301', 'AREA # 13301'],
-                'Region': ['Colina', 'Colina'],
                 'Taxonomy': ['W+WS/H:1,2', 'W+WS/H:1,2'],
                 'Dwellings': [107.5, 107.5],
                 'Buildings': [100.0, 50.0],
                 'Repl-cost-USD-bdg': [360000, 450000],
                 'Population': [446.5, 446.5],
-                'name': ['Colina', 'Colina'],
                 'Damage': ['D0', 'D1']
             }
         })
@@ -218,7 +199,6 @@ class TestExposure(unittest.TestCase):
 
         self.assertEqual('SARA_v1.0', exposure_cell.schema)
         self.assertEqual('CHL.14.1.1_1', exposure_cell.gid)
-        self.assertEqual('Colina', exposure_cell.name)
         self.assertEqual(geometry, exposure_cell.geometry)
         lon, lat = exposure_cell.get_lon_lat_of_centroid()
         self.assertEqual(14, lon)
@@ -239,11 +219,9 @@ class TestExposure(unittest.TestCase):
             damage_state=0,
             n_buildings=100.0,
             area_id='AREA # 13301',
-            region='Colina',
             dwellings=107.5,
             repl_cost_usd_bdg=360000,
             population=446.5,
-            name='Colina'
         )
         tdb2 = dict(
             schema='SARA_v1.0',
@@ -251,24 +229,20 @@ class TestExposure(unittest.TestCase):
             damage_state=1,
             n_buildings=50.0,
             area_id='AREA # 13301',
-            region='Colina',
             dwellings=107.5,
             repl_cost_usd_bdg=360000,
             population=446.5,
-            name='Colina'
         )
         geometry = wkt.loads('POINT(14 51)')
         exposure_cell = exposure.ExposureCell(
             schema='SARA_v1.0',
             gid='CHL.14.1.1_1',
-            name='Colina',
             geometry=geometry,
             taxonomies=[tdb1, tdb2]
         )
 
         self.assertEqual('SARA_v1.0', exposure_cell.schema)
         self.assertEqual('CHL.14.1.1_1', exposure_cell.gid)
-        self.assertEqual('Colina', exposure_cell.name)
         self.assertEqual(geometry, exposure_cell.geometry)
         lon, lat = exposure_cell.get_lon_lat_of_centroid()
         self.assertEqual(14, lon)
@@ -317,7 +291,6 @@ class TestExposure(unittest.TestCase):
         '''
         series = pd.Series({
             'W+WS/H:1,2_D3': 100.0,
-            'name': 'Colina',
             'gid': 'xyz123',
             # won't be used here
             'geometry': 'POINT(1 1)',
@@ -334,7 +307,6 @@ class TestExposure(unittest.TestCase):
         self.assertEqual('W+WS/H:1,2', tdb["taxonomy"])
         self.assertEqual(3, tdb["damage_state"])
         self.assertEqual(100.0, tdb["n_buildings"])
-        self.assertEqual('Colina', tdb["name"])
 
     def test_remove_prefix_d_for_damage_state(self):
         '''
@@ -351,13 +323,11 @@ class TestExposure(unittest.TestCase):
         '''
         series = pd.Series({
             'id': 'AREA # 13301',
-            'Region': 'Colina',
             'Taxonomy': 'W+WS/H:1,2',
             'Dwellings': 107.5,
             'Buildings': 100.0,
             'Repl-cost-USD-bdg': 360000,
             'Population': 446.5,
-            'name': 'Colina',
             'Damage': 'D0'
         })
 
@@ -370,13 +340,11 @@ class TestExposure(unittest.TestCase):
         self.assertEqual(0, tdb["damage_state"])
         self.assertEqual(100.0, tdb["n_buildings"])
         self.assertEqual('AREA # 13301', tdb["area_id"])
-        self.assertEqual('Colina', tdb["region"])
         self.assertLess(107.4, tdb["dwellings"])
         self.assertLess(tdb["dwellings"], 107.6)
         self.assertEqual(360000, tdb["repl_cost_usd_bdg"])
         self.assertLess(446.4, tdb["population"])
         self.assertLess(tdb["population"], 446.6)
-        self.assertEqual('Colina', tdb["name"])
 
     def test_taxonomy_data_bag(self):
         '''
@@ -388,11 +356,9 @@ class TestExposure(unittest.TestCase):
             damage_state=0,
             n_buildings=100.0,
             area_id='AREA # 13301',
-            region='Colina',
             dwellings=107.5,
             repl_cost_usd_bdg=360000,
             population=446.5,
-            name='Colina'
         )
 
         self.assertEqual('SARA_v1.0', tdb["schema"])
@@ -400,13 +366,11 @@ class TestExposure(unittest.TestCase):
         self.assertEqual(0, tdb["damage_state"])
         self.assertEqual(100.0, tdb["n_buildings"])
         self.assertEqual('AREA # 13301', tdb["area_id"])
-        self.assertEqual('Colina', tdb["region"])
         self.assertLess(107.4, tdb["dwellings"])
         self.assertLess(tdb["dwellings"], 107.6)
         self.assertEqual(360000, tdb["repl_cost_usd_bdg"])
         self.assertLess(446.4, tdb["population"])
         self.assertLess(tdb["population"], 446.6)
-        self.assertEqual('Colina', tdb["name"])
 
     def test_fill_cell_step_by_step(self):
         '''
@@ -422,17 +386,14 @@ class TestExposure(unittest.TestCase):
             damage_state=0,
             n_buildings=100.0,
             area_id='AREA # 13301',
-            region='Colina',
             dwellings=107.5,
             repl_cost_usd_bdg=360000,
             population=446.5,
-            name='Colina'
         )
 
         geometry = wkt.loads('POINT(14 51)')
         exposure_cell = exposure.ExposureCell(
             schema='SARA_v1.0',
-            name='Colina',
             gid='CHL.14.1.1_1',
             geometry=geometry,
             taxonomies=[])
@@ -456,11 +417,9 @@ class TestExposure(unittest.TestCase):
             damage_state=1,
             n_buildings=100.0,
             area_id='AREA # 13301',
-            region='Colina',
             dwellings=107.5,
             repl_cost_usd_bdg=360000,
             population=446.5,
-            name='Colina'
         )
         exposure_cell.add_taxonomy(tdb2)
         self.assertEqual(2, len(exposure_cell.taxonomies))
@@ -474,11 +433,10 @@ class TestExposure(unittest.TestCase):
         Tests the creation of an empty
         exposure cell from an existing one.
         Should still have the same
-        name, id and geometry, but no taxonomy data.
+        id and geometry, but no taxonomy data.
         '''
         geometry1 = wkt.loads('POINT(14 51)')
         series1 = pd.Series({
-            'name': 'Colina',
             'gc_id': 'CHL.14.1.1_1',
             'geometry': geometry1,
             'W+WS/H:1,2': 100.0,
@@ -492,7 +450,6 @@ class TestExposure(unittest.TestCase):
 
         empty_exposure_cell = exposure_cell1.without_taxonomies()
 
-        self.assertEqual('Colina', empty_exposure_cell.name)
         self.assertEqual('CHL.14.1.1_1', empty_exposure_cell.gid)
         self.assertEqual(geometry1, empty_exposure_cell.geometry)
         self.assertEqual([], empty_exposure_cell.taxonomies)

--- a/test_loss.py
+++ b/test_loss.py
@@ -31,7 +31,6 @@ class TestLoss(unittest.TestCase):
         '''
         geometry1 = wkt.loads('POINT(14 51)')
         series1 = pd.Series({
-            'name': 'Colina',
             'gc_id': 'CHL.14.1.1_1',
             'geometry': geometry1,
             'W+WS/H:1,2': 100.0,
@@ -62,7 +61,6 @@ class TestLoss(unittest.TestCase):
 
         self.assertEqual('$', loss_cell1.loss_unit)
         self.assertEqual(10, loss_cell1.loss_value)
-        self.assertEqual('Colina', loss_cell1.name)
         self.assertEqual('CHL.14.1.1_1', loss_cell1.gid)
         self.assertEqual(geometry1, loss_cell1.geometry)
 
@@ -71,7 +69,6 @@ class TestLoss(unittest.TestCase):
         loss_dataframe = loss_list.to_dataframe()
 
         self.assertEqual(geometry1, loss_dataframe['geometry'][0])
-        self.assertEqual('Colina', loss_dataframe['name'][0])
         self.assertEqual(10, loss_dataframe['loss_value'][0])
         self.assertEqual('$', loss_dataframe['loss_unit'][0])
 

--- a/test_transition.py
+++ b/test_transition.py
@@ -24,7 +24,6 @@ class TestTransition(unittest.TestCase):
         '''
         geometry1 = wkt.loads('POINT(14 51)')
         series1 = pd.Series({
-            'name': 'Colina',
             'gc_id': 'CHL.14.1.1_1',
             'geometry': geometry1,
             'W+WS/H:1,2': 100.0,
@@ -65,7 +64,6 @@ class TestTransition(unittest.TestCase):
         first_transition = transition_cell1.transitions[0]
         self.assertEqual(20, first_transition.n_buildings)
 
-        self.assertEqual('Colina', transition_cell1.name)
         self.assertEqual('CHL.14.1.1_1', transition_cell1.gid)
         self.assertEqual(geometry1, transition_cell1.geometry)
 
@@ -81,7 +79,6 @@ class TestTransition(unittest.TestCase):
         transition_list = transition.TransitionCellList([transition_cell1])
         transition_dataframe = transition_list.to_dataframe()
 
-        self.assertEqual('Colina', transition_dataframe['name'][0])
         self.assertEqual('CHL.14.1.1_1', transition_dataframe['gid'][0])
         self.assertEqual(geometry1, transition_dataframe['geometry'][0])
         self.assertEqual(schema, transition_dataframe['schema'][0])

--- a/transition.py
+++ b/transition.py
@@ -15,10 +15,9 @@ class TransitionCell:
     Cell with gid, name and geometry
     to store the transitions in.
     '''
-    def __init__(self, schema, gid, name, geometry, transitions):
+    def __init__(self, schema, gid, geometry, transitions):
         self.schema = schema
         self.gid = gid
-        self.name = name
         self.geometry = geometry
         self.transitions = transitions
         self._transition_idx_by_transition_key = {}
@@ -50,7 +49,6 @@ class TransitionCell:
         '''
         series = pd.Series({
             'gid': self.gid,
-            'name': self.name,
             'geometry': self.geometry,
             'schema': self.schema,
             'transitions': {
@@ -78,13 +76,12 @@ class TransitionCell:
     def from_exposure_cell(cls, exposure_cell):
         '''
         Creates an transition cell by using the
-        names, the gid, the schema and the geometry of
+        the gid, the schema and the geometry of
         the exposure cell.
         '''
         return cls(
             schema=exposure_cell.schema,
             gid=exposure_cell.gid,
-            name=exposure_cell.name,
             geometry=exposure_cell.geometry,
             transitions=[]
         )


### PR DESCRIPTION
We now have exposure models that may not have a name nor a region
value that can be processed. So to be able to work with this models
we need to remove the processing of those attributes.
It also may reduce the file size of the results as well.